### PR TITLE
Fix default transport dsn, cover with tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 .gitattributes     export-ignore
 .gitignore         export-ignore
 README.md          export-ignore
+tests              export-ignore
+phpunit.xml        export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^8.5 || ^9.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,8 @@
                 "Onliner\\Laravel\\CommandBus\\Providers\\CommandBusProvider"
             ]
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/config/commandbus.php
+++ b/config/commandbus.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Onliner\CommandBus\Retry\Policy;
+use Onliner\Laravel\CommandBus\Factory\TransportFactory;
 
 return [
     'remote' => [
@@ -14,7 +15,7 @@ return [
             ],
         ],
         'transport' => [
-            'dsn' => 'memory://',
+            'dsn' => TransportFactory::DEFAULT,
             'options' => [
                 // 'key' => 'value',
             ],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Laravel command bus">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Factory/TransportFactory.php
+++ b/src/Factory/TransportFactory.php
@@ -11,7 +11,7 @@ use Onliner\Laravel\CommandBus\Exception;
 
 class TransportFactory
 {
-    public const DEFAULT = 'memory://';
+    public const DEFAULT = 'memory://memory';
 
     /**
      * @param string $dsn

--- a/tests/Factory/TransportFactoryTest.php
+++ b/tests/Factory/TransportFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factory;
+
+use Onliner\CommandBus\Remote\InMemory\InMemoryTransport;
+use Onliner\Laravel\CommandBus\Exception\UnknownTransportException;
+use Onliner\Laravel\CommandBus\Factory\TransportFactory;
+use PHPUnit\Framework\TestCase;
+
+final class TransportFactoryTest extends TestCase
+{
+    public function testInMemoryTransportCreated(): void
+    {
+        $transport = TransportFactory::create(TransportFactory::DEFAULT);
+        self::assertInstanceOf(InMemoryTransport::class, $transport);
+    }
+
+    public function testExceptionThrowsWhenTransportDsnIsInvalid(): void
+    {
+        self::expectException(UnknownTransportException::class);
+        TransportFactory::create('memory://');
+    }
+}


### PR DESCRIPTION
This PR fixes exception `UnknownTransportException` from `TransportFactory` with default transport dsn `memory://`, because `parse_url` return false.